### PR TITLE
when verifying a method with 'exactly = 0', return verification match…

### DIFF
--- a/mockk/src/main/kotlin/io/mockk/impl/Verification.kt
+++ b/mockk/src/main/kotlin/io/mockk/impl/Verification.kt
@@ -92,11 +92,15 @@ internal class UnorderedCallVerifierImpl(private val gw: MockKGatewayImpl) : Cal
         }
         val result = when (allCallsForMockMethod.size) {
             0 -> {
-                if (allCallsForMock.isEmpty()) {
-                    VerificationResult(false, "$callIdxMsg No calls for $mock/${call.matcher.method.toStr()}")
+                if (min == 0 && max == 0) {
+                    VerificationResult(true)
                 } else {
-                    VerificationResult(false, "$callIdxMsg No calls for $mock/${call.matcher.method.toStr()}.\n" +
-                            "Calls to same mock:\n" + formatCalls(allCallsForMock))
+                    if (allCallsForMock.isEmpty()) {
+                        VerificationResult(false, "$callIdxMsg No calls for $mock/${call.matcher.method.toStr()}")
+                    } else {
+                        VerificationResult(false, "$callIdxMsg No calls for $mock/${call.matcher.method.toStr()}.\n" +
+                                "Calls to same mock:\n" + formatCalls(allCallsForMock))
+                    }
                 }
             }
             1 -> {

--- a/mockk/src/test/kotlin/io/mockk/MockKTestSuite.kt
+++ b/mockk/src/test/kotlin/io/mockk/MockKTestSuite.kt
@@ -174,6 +174,9 @@ class MockKTestSuite : StringSpec({
         verify(exactly = 0, inverse = true) {
             mock.otherOp(0, 2)
         }
+        verify(exactly = 0) {
+            mock.neverCalled()
+        }
     }.config(enabled = true)
 
     "stubbing actions" {
@@ -659,4 +662,6 @@ class MockCls {
     fun chainOp(a: Int = 1, b: Int = 2) = if (a + b > 0) MockCls() else MockCls()
     fun arrayOp(array: Array<Any>): Array<Any> = array.map { (it as Int) + 1 }.toTypedArray()
     fun arrayOp(array: Array<Array<Any>>): Array<Array<Any>> = array.map { it.map { ((it as Int) + 1) as Any }.toTypedArray() }.toTypedArray()
+
+    fun neverCalled():Int = 1
 }


### PR DESCRIPTION
… if a method is never called instead of an error that the method is never called

Thanks for creating Mockk. While using your library I wanted to verify that a certain method on the mock is never called by using verify(exactly = 0). This always resulted in a error "Verification failed: call 1 of 1. No calls for mockk... " while that should result in a verification success. Therefor I made a fix to check the min and max in case of no calls to the mock method. If they are 0, it returns a verification success instead of failure. When min and max are not 0, everything stays the same and a failure is reported. I also added a unit test case for this fix.