### PR TITLE
Allow mock creation with a KClass

### DIFF
--- a/common/src/main/kotlin/io/mockk/MockK.kt
+++ b/common/src/main/kotlin/io/mockk/MockK.kt
@@ -12,8 +12,19 @@ inline fun <reified T : Any> mockk(
     relaxed: Boolean = false,
     vararg moreInterfaces: KClass<*>,
     block: T.() -> Unit = {}
+): T = mockk(T::class, name, relaxed, *moreInterfaces, block = block)
+
+/**
+ * Builds a new mock for specified class
+ */
+inline fun <T : Any> mockk(
+        klazz: KClass<T>,
+        name: String? = null,
+        relaxed: Boolean = false,
+        vararg moreInterfaces: KClass<*>,
+        block: T.() -> Unit = {}
 ): T = MockK.useImpl {
-    MockKDsl.internalMockk(name, relaxed, *moreInterfaces, block = block)
+    MockKDsl.internalMockk(klazz, name, relaxed, *moreInterfaces, block = block)
 }
 
 /**

--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -24,8 +24,19 @@ object MockKDsl {
         relaxed: Boolean = false,
         vararg moreInterfaces: KClass<*>,
         block: T.() -> Unit = {}
+    ): T = internalMockk(T::class, name, relaxed, *moreInterfaces, block = block)
+
+    /**
+     * Builds a new mock for specified class
+     */
+    inline fun <T : Any> internalMockk(
+            klazz: KClass<T>,
+            name: String? = null,
+            relaxed: Boolean = false,
+            vararg moreInterfaces: KClass<*>,
+            block: T.() -> Unit = {}
     ): T {
-        val mock = MockKGateway.implementation().mockFactory.mockk(T::class, name, relaxed, moreInterfaces)
+        val mock = MockKGateway.implementation().mockFactory.mockk(klazz, name, relaxed, moreInterfaces)
         block(mock)
         return mock
     }


### PR DESCRIPTION
This allows us to create mocks when interacting with non-Kotlin code
(ex: JUnit5 extensions).

I wanted to create a JUnit5 extension (like [this one](https://github.com/junit-team/junit5-samples/blob/master/junit5-mockito-extension/src/main/java/com/example/mockito/MockitoExtension.java) for Mockito) to handle injecting mocks in function parameters in my tests, but couldn't since JUnit only gives us a `Class`, making it impossible to call the `mockk<T>(...)` function.