### PR TITLE
fix JDK7 compatibility

### DIFF
--- a/mockk/src/main/kotlin/io/mockk/impl/InternalPlatform.kt
+++ b/mockk/src/main/kotlin/io/mockk/impl/InternalPlatform.kt
@@ -20,7 +20,7 @@ actual object InternalPlatform {
 
     actual fun ref(obj: Any): Ref = CommonRef(obj)
 
-    actual fun hkd(obj: Any): String = Integer.toUnsignedString(InternalPlatformDsl.identityHashCode(obj), 16)
+    actual fun hkd(obj: Any): String = Integer.toHexString(InternalPlatformDsl.identityHashCode(obj))
 
     actual fun isPassedByValue(cls: KClass<*>): Boolean {
         return when (cls) {


### PR DESCRIPTION
Now mockk is unusable with JDK7 'cause `Integer.toUnsignedString()` is private in it. This PR is an attempt to fix this incompatibility.